### PR TITLE
Simplify login

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ netresearch_docker_containers:
   - name: string
     image: string
     login: # dictionary or undefined
+      registry: string
       username: string
       password: string
     networks: [] # Just like the one in `community.general.docker_container`
@@ -63,6 +64,7 @@ netresearch_docker_containers:
   - name: raybeam
     image: ghcr.io/netresearch/raybeam:latest
     login: # This will log into the GitHub Container Registry
+      registry: "ghcr.io"
       username: "yourusername"
       password: "yourpassword"
     restart_policy: unless-stopped

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -38,6 +38,15 @@ provisioner:
             networks:
               - name: nginx
               - name: traefik
+          - name: registry_login
+            image: nginx
+            login:
+              registry: docker.io
+              username: ${DOCKER_USERNAME}
+              password: ${DOCKER_PASSWORD}
+            networks:
+              - name: nginx
+              - name: traefik
 
 verifier:
   name: ansible

--- a/tasks/container.yml
+++ b/tasks/container.yml
@@ -3,21 +3,12 @@
 # main.yml since Ansible doesn't support `loop`ing `block` statements.
 # ref: https://ericsysmin.com/2019/06/20/how-to-loop-blocks-of-code-in-ansible/
 
-- name: Set login required fact
-  ansible.builtin.set_fact:
-    _login_required: "{{ (item.login | default(false)) is mapping }}"
-
-- name: Set registry fact
-  ansible.builtin.set_fact:
-    _registry: "{{ ((item.image.split('/') | length) > 1) | ternary(item.image.split('/')[0], omit) }}"
-  when: _login_required
-
 - name: Log into container registry
   community.general.docker_login:
-    registry: "{{ _registry }}"
+    registry: "{{ item.login.registry }}"
     username: "{{ item.login.username }}"
     password: "{{ item.login.password }}"
-  when: _login_required
+  when: (item.login | default(false)) is mapping
   changed_when: false
 
 - name: "Start container {{ item.name }}"
@@ -40,9 +31,9 @@
 
 - name: Log out of container registry
   community.general.docker_login:
-    registry: "{{ _registry }}"
+    registry: "{{ item.login.registry }}"
     username: "{{ item.login.username }}"
     password: "{{ item.login.password }}"
     state: absent
-  when: _login_required
+  when: (item.login | default(false)) is mapping
   changed_when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,7 @@
   with_subelements:
     - "{{ netresearch_docker_containers }}"
     - networks
+  no_log: true
 
 - name: Create networks
   loop: "{{ netresearch_docker_containers_network_names | default([]) | flatten | unique }}"


### PR DESCRIPTION
## remove
- :heavy_minus_sign:  `set_facts` tasks in order to reduce unnecessary magic

## add
- :heavy_check_mark: introduce `login.registry` variable so users can specify the private registry
- :heavy_check_mark: test case with an image pulled with a registry specified

## change
- :lady_beetle: do not leak credentials in `Uniquify network names` task