### PR TITLE
Skip containers without a networks key in Uniquify network names

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -44,6 +44,13 @@ provisioner:
           - name: no_networks
             image: traefik/whoami
             networks: []
+          # Tombstone shape: state: absent with the `networks` key omitted
+          # entirely. Regression guard for the with_subelements skip_missing
+          # fix — an empty list ([]) does not reproduce the failure, a missing
+          # key does.
+          - name: decommissioned
+            image: traefik/whoami
+            state: absent
 
 verifier:
   name: ansible

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -16,7 +16,7 @@
       ansible.builtin.assert:
         that:
           - "item.exists"
-          - "item.container.State.Status == 'running'"
+          - "item.exists and item.container.State.Status == 'running'"
 
     - name: "Absent container assertions"
       loop: "{{ status.results }}"
@@ -34,7 +34,7 @@
         - skip_missing: true
 
     - name: "Get status of networks"
-      loop: "{{ netresearch_docker_containers_network_names | flatten | unique }}"
+      loop: "{{ netresearch_docker_containers_network_names | default([]) | flatten | unique }}"
       register: network_status
       community.docker.docker_network_info:
         name: "{{ item.name }}"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -10,12 +10,20 @@
       community.docker.docker_container_info:
         name: "{{ item.name }}"
 
-    - name: "Container assertions"
+    - name: "Present container assertions"
       loop: "{{ status.results }}"
+      when: (item.item.state | default('started')) != 'absent'
       ansible.builtin.assert:
         that:
           - "item.exists"
           - "item.container.State.Status == 'running'"
+
+    - name: "Absent container assertions"
+      loop: "{{ status.results }}"
+      when: (item.item.state | default('started')) == 'absent'
+      ansible.builtin.assert:
+        that:
+          - "not item.exists"
 
     - name: Uniquify network names
       ansible.builtin.set_fact:
@@ -23,6 +31,7 @@
       with_subelements:
         - "{{ netresearch_docker_containers }}"
         - networks
+        - skip_missing: true
 
     - name: "Get status of networks"
       loop: "{{ netresearch_docker_containers_network_names | flatten | unique }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,7 @@
   with_subelements:
     - "{{ netresearch_docker_containers }}"
     - networks
+    - skip_missing: true
   no_log: true
 
 - name: Create networks


### PR DESCRIPTION
## Problem

Running the role with a container that omits the `networks` key — the shape of a decommission tombstone — fails at the **Uniquify network names** task:

```
The lookup plugin 'subelements' failed: could not find 'networks' key in iterated item
'{'name': 'stats_timetracker_nr', 'image': 'ghcr.io/netresearch/timetracker-ui', 'state': 'absent'}'
```

`with_subelements` hard-fails on a missing subkey. The `Start container` task already tolerates a missing `networks` via `default(omit)` — only this uniquify pre-step did not, so a `state: absent` container (which legitimately has no networks) could never be reconciled.

## Fix

- `tasks/main.yml`: add `skip_missing: true` to the `with_subelements` flags, so containers without a `networks` key are skipped during uniquification.
- `molecule/default/molecule.yml`: add a regression case — a `state: absent`, network-less `decommissioned` container. Note an empty list (`networks: []`) does **not** reproduce the failure; a missing key does.
- `molecule/default/verify.yml`: add `skip_missing: true` to its own uniquify step and split the container assertions into present (`exists` + running) and absent (`not exists`).

## Verification

`molecule test` (default scenario) passes end-to-end locally with the new case:

- **converge** Successful — incl. `Start container decommissioned`
- **idempotence** Successful (changed=0) — uniquify runs over all containers including the network-less one
- **verify** Successful — present containers running, `decommissioned` asserted `exists: False`

yamllint and ansible-lint clean on the changed files.

Refs: NRS-4501