### PR TITLE
fix(security): stop leaking container login credentials in play output

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -1,5 +1,8 @@
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   molecule:
     name: Run molecule against role

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -32,3 +32,38 @@ jobs:
       - run: ansible-galaxy install -r requirements.yml
 
       - run: ansible-lint .
+
+  no-log-leak:
+    name: Guard container login credentials against play-output leak
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          cache: pip
+
+      - run: python3 -m pip install ansible molecule molecule-docker 'requests<2.32.0'
+
+      - name: Converge the no-log-leak scenario and assert the token never appears
+        env:
+          ANSIBLE_ALLOW_BROKEN_CONDITIONALS: "true"
+          ANSIBLE_FORCE_COLOR: "0"
+        run: |
+          out="$(molecule converge -s no-log-leak 2>&1)"; rc=$?
+          echo "$out"
+          # Security assertion first, so an incidental converge failure can never hide a leak.
+          if grep -q 'CANARY_DEPLOY_TOKEN_must_not_appear' <<<"$out"; then
+            echo "::error::login credential leaked into play output; keep loop_control.label on the include loop"
+            exit 1
+          fi
+          # The converge must actually exercise the login path, else the guard is vacuous.
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::converge failed (rc=$rc); guard did not exercise the login path"
+            exit 1
+          fi
+          echo "ok: login credential never appeared in play output"
+
+      - name: Destroy
+        if: always()
+        run: molecule destroy -s no-log-leak || true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .kitchen/
 .kitchen.local.yml
 .idea/
+.ansible/

--- a/molecule/no-log-leak/converge.yml
+++ b/molecule/no-log-leak/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  tasks:
+    - name: "Include netresearch.docker_containers"
+      ansible.builtin.include_role:
+        name: "netresearch.docker_containers"

--- a/molecule/no-log-leak/molecule.yml
+++ b/molecule/no-log-leak/molecule.yml
@@ -1,0 +1,47 @@
+---
+# Regression scenario for the container-login credential leak.
+# Runs the role with a single login-bearing container whose password is a
+# canary; CI captures the converge output and fails if the canary appears,
+# which it would if the "Start container" include loop lost its
+# loop_control.label (see tasks/main.yml).
+dependency:
+  name: galaxy
+  options:
+    role-file: requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: instance-no-log-leak
+    image: geerlingguy/docker-debian12-ansible:latest
+    privileged: true
+    pre_build_image: true
+    cgroupns: host
+    cgroupns_mode: host
+    command: /lib/systemd/systemd
+    tmpfs:
+      - /run
+      - /run/lock
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    groups:
+      - containers
+
+provisioner:
+  name: ansible
+  options:
+    D: true
+  inventory:
+    group_vars:
+      containers:
+        netresearch_docker_containers:
+          - name: leakcanary
+            image: traefik/whoami
+            login:
+              registry: localhost:5000
+              username: leakcanary
+              password: "CANARY_DEPLOY_TOKEN_must_not_appear"
+
+verifier:
+  name: ansible

--- a/molecule/no-log-leak/prepare.yml
+++ b/molecule/no-log-leak/prepare.yml
@@ -1,0 +1,32 @@
+---
+- name: Prepare
+  hosts: all
+  become: true
+  vars:
+    pip_install_packages:
+      - docker
+      - 'requests<2.32.0'
+    # Use vfs storage driver to avoid overlay-on-overlay mount failures in DinD
+    docker_daemon_options:
+      storage-driver: vfs
+
+  pre_tasks:
+    - name: Update cache
+      ansible.builtin.apt:
+        update_cache: true
+
+  roles:
+    - geerlingguy.pip
+    - geerlingguy.docker
+
+  post_tasks:
+    # A no-auth registry is enough: docker_login succeeds against it, so the
+    # converge stays green and the only thing under test is whether the deploy
+    # token shows up in the play output.
+    - name: Start a throwaway no-auth registry for the canary login
+      community.docker.docker_container:
+        name: leaktest-registry
+        image: registry:2
+        published_ports:
+          - "5000:5000"
+        state: started

--- a/tasks/container.yml
+++ b/tasks/container.yml
@@ -10,7 +10,6 @@
     password: "{{ item.login.password }}"
   when: (item.login | default(false)) is mapping
   changed_when: false
-  no_log: true
 
 - name: "Start container {{ item.name }}"
   community.general.docker_container:
@@ -41,4 +40,3 @@
     state: absent
   when: (item.login | default(false)) is mapping
   changed_when: false
-  no_log: true

--- a/tasks/container.yml
+++ b/tasks/container.yml
@@ -10,6 +10,7 @@
     password: "{{ item.login.password }}"
   when: (item.login | default(false)) is mapping
   changed_when: false
+  no_log: true
 
 - name: "Start container {{ item.name }}"
   community.general.docker_container:
@@ -40,3 +41,4 @@
     state: absent
   when: (item.login | default(false)) is mapping
   changed_when: false
+  no_log: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,3 +31,9 @@
 - name: Start container
   ansible.builtin.include_tasks: container.yml
   loop: "{{ netresearch_docker_containers }}"
+  loop_control:
+    # Without an explicit label Ansible prints the whole loop item on the
+    # "included: container.yml ... => (item=...)" line at default verbosity,
+    # which dumps item.login.password (a resolved registry deploy token) in
+    # cleartext. Limit the label to the container name.
+    label: "{{ item.name }}"


### PR DESCRIPTION
## Problem

The `Start container` include loop in `tasks/main.yml` had no `loop_control.label`, so at default verbosity Ansible printed the entire loop item on the `included: container.yml ... => (item=...)` line — including `item.login.password`, which is a registry deploy token resolved from a vault lookup at the call site. Any run that logs into a registry leaked the token in cleartext play output.

`community.general.docker_login` already masks its own `password` argument, so the include-loop item label was the sole leak vector.

## Fix

- `loop_control.label: "{{ item.name }}"` on the container include loop, so only the container name is shown.
- `no_log: true` on the login/logout `docker_login` tasks as defense-in-depth on the credential-handling steps.

## Regression test

- New `molecule/no-log-leak` scenario: a single login-bearing container against a throwaway no-auth registry started in `prepare.yml`.
- New CI job converges the scenario and fails if the canary deploy token appears anywhere in the play output.

Verified locally: the job is green with the fix, and red when the `loop_control.label` is removed (the token reappears on the `included: ... (item=...)` line).

## Verification

- `molecule test` (default scenario): passes.
- `molecule converge -s no-log-leak`: token absent with the fix; present without it.
- `ansible-lint` (production profile) and `yamllint`: clean.
