### PR TITLE
feat: limit a run to selected containers via netresearch_docker_containers_only

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,29 @@ This Ansible role provides a way to deploy multiple Docker containers.
 
 ## Variables
 
-| Name                            | Default Value | Description |
-| ------------------------------- | ------------- | ----------- |
-| `netresearch_docker_containers` | `[]`          | Containers  |
+| Name                                 | Default Value | Description |
+| ------------------------------------ | ------------- | ----------- |
+| `netresearch_docker_containers`      | `[]`          | Containers  |
+| `netresearch_docker_containers_only` | `[]`          | Limit a run to these container names. Empty manages all. Accepts a list or a comma-separated string. |
+
+### Limiting a run to specific containers
+
+By default the role reconciles **every** container in
+`netresearch_docker_containers`. To act on only a subset (for example to deploy
+a single container without re-pulling/recreating the others on a shared host),
+set `netresearch_docker_containers_only`. It accepts a list or a
+comma-separated string and only manages the networks of the selected
+containers. An unknown name fails the run early.
+
+```shell
+# single container
+ansible-playbook site.yml --limit myhost --tags docker-containers \
+  -e 'netresearch_docker_containers_only=dns'
+
+# a group of containers
+ansible-playbook site.yml --limit myhost --tags docker-containers \
+  -e '{"netresearch_docker_containers_only": ["dns", "composer"]}'
+```
 
 ### Container definition
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,9 @@
 ---
 netresearch_docker_containers: []
+
+# Optional: limit a run to specific container(s) by name.
+# Empty list (default) manages every defined container — backwards compatible.
+# Accepts a list (["dns", "composer"]) or a comma-separated string, the latter
+# being convenient on the command line:
+#   ansible-playbook ... -e 'netresearch_docker_containers_only=dns'
+netresearch_docker_containers_only: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,10 +19,10 @@
     #   -e 'netresearch_docker_containers_only=dns'
     netresearch_docker_containers_only_list: >-
       {{
-        (netresearch_docker_containers_only | default([]))
-        if ((netresearch_docker_containers_only | default([])) is sequence
-            and (netresearch_docker_containers_only | default([])) is not string)
-        else ((netresearch_docker_containers_only | default('')) | string
+        (netresearch_docker_containers_only | default([], true))
+        if ((netresearch_docker_containers_only | default([], true)) is sequence
+            and (netresearch_docker_containers_only | default([], true)) is not string)
+        else ((netresearch_docker_containers_only | default('', true)) | string
               | split(',') | map('trim') | reject('equalto', '') | list)
       }}
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,12 +12,55 @@
   when: >
     docker_status.failed | bool or docker_status.state != "started"
 
+- name: Resolve the container selection filter to a list
+  ansible.builtin.set_fact:
+    # Accept either a real list (["dns", "composer"]) or a comma-separated
+    # string, the latter being convenient on the command line:
+    #   -e 'netresearch_docker_containers_only=dns'
+    netresearch_docker_containers_only_list: >-
+      {{
+        (netresearch_docker_containers_only | default([]))
+        if ((netresearch_docker_containers_only | default([])) is sequence
+            and (netresearch_docker_containers_only | default([])) is not string)
+        else ((netresearch_docker_containers_only | default('')) | string
+              | split(',') | map('trim') | reject('equalto', '') | list)
+      }}
+
+- name: Fail when a requested container is not defined
+  ansible.builtin.fail:
+    msg: >-
+      netresearch_docker_containers_only requested unknown container(s):
+      {{ netresearch_docker_containers_only_list
+         | difference(netresearch_docker_containers | map(attribute='name') | list) }}
+  when:
+    - netresearch_docker_containers_only_list | length > 0
+    - (netresearch_docker_containers_only_list
+       | difference(netresearch_docker_containers | map(attribute='name') | list))
+       | length > 0
+
+- name: Select the containers to manage (all unless a filter is given)
+  ansible.builtin.set_fact:
+    netresearch_docker_containers_selected: >-
+      {{
+        netresearch_docker_containers
+        if (netresearch_docker_containers_only_list | length == 0)
+        else (netresearch_docker_containers
+              | selectattr('name', 'in', netresearch_docker_containers_only_list) | list)
+      }}
+
+- name: Report the active container selection
+  ansible.builtin.debug:
+    msg: >-
+      Limiting this run to {{ netresearch_docker_containers_selected | map(attribute='name') | list }}
+      (of {{ netresearch_docker_containers | map(attribute='name') | list }})
+  when: netresearch_docker_containers_only_list | length > 0
+
 - name: Uniquify network names
   ansible.builtin.set_fact:
     netresearch_docker_containers_network_names: >
       {{ netresearch_docker_containers_network_names | default([]) + [ item.1 ] }}
   with_subelements:
-    - "{{ netresearch_docker_containers }}"
+    - "{{ netresearch_docker_containers_selected }}"
     - networks
     - skip_missing: true
   no_log: true
@@ -30,7 +73,7 @@
 
 - name: Start container
   ansible.builtin.include_tasks: container.yml
-  loop: "{{ netresearch_docker_containers }}"
+  loop: "{{ netresearch_docker_containers_selected }}"
   loop_control:
     # Without an explicit label Ansible prints the whole loop item on the
     # "included: container.yml ... => (item=...)" line at default verbosity,


### PR DESCRIPTION
## What

Adds an optional `netresearch_docker_containers_only` variable to limit a run to
specific container(s) by name. Empty (default) manages **all** defined
containers, so existing behaviour is unchanged.

- Accepts a **list** (`["dns", "composer"]`) or a **comma-separated string**
  (`-e 'netresearch_docker_containers_only=dns'`).
- Network creation is scoped to the selected containers.
- An unknown container name **fails the run early** (typo guard).
- A `debug` line reports the active selection when the filter is set.

## Why

On shared hosts the role uses `pull: true` and recreates every container in
`netresearch_docker_containers`. Deploying a single image therefore re-pulls and
can recreate unrelated **production** containers on the same host. This lets an
operator target just the container(s) they intend to change.

```shell
ansible-playbook site.yml --limit myhost --tags docker-containers \
  -e 'netresearch_docker_containers_only=dns'
```

## Testing

- `yamllint` (repo `.yamllint`): clean.
- `ansible-lint`: `0 failure(s), 0 warning(s)`, profile `production`.
- Backwards compatible: with the default empty filter the selected set equals
  the full list, so the existing molecule scenarios behave unchanged.

A dedicated molecule scenario asserting the filter (selected present / others
absent) can follow if desired.
