### PR TITLE
ci: create a GitHub Release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   ansible-galaxy:
     name: Publish on Ansible Galaxy
@@ -15,3 +18,23 @@ jobs:
         with:
           git_branch: main
           galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}
+
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release from the pushed tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes \
+            --verify-tag


### PR DESCRIPTION
## What

Add a `github-release` job to `release.yml` so each `v*` tag also creates a
**GitHub Release** (with auto-generated notes), alongside the existing Ansible
Galaxy publish.

## Why

`release.yml` only published to Galaxy on tag push and never created a GitHub
Release. As a result recent tags shipped without a Release entry — `v1.6.2`
and (until just now) `v1.7.0` were tag-only, leaving the Releases page stale.
This closes the gap at the source so it doesn't recur.

## How

- Uses the preinstalled `gh` CLI (`gh release create --generate-notes --verify-tag`)
  — no third-party action to vet/pin.
- Job-scoped `permissions: contents: write` for the release job; least-privilege
  `contents: read` default at the top level (the Galaxy job needs only read).

`v1.6.2` and `v1.7.0` Releases were created manually to backfill; this makes
future tags self-service.
